### PR TITLE
move goals service to separate service init commit (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.2.1</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.khomishchak</groupId>
+	<artifactId>goals-service</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>goals-service</name>
+	<description>goals-service</description>
+	<properties>
+		<java.version>17</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+				<configuration>
+					<excludes>
+						<exclude>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok</artifactId>
+						</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/main/java/com/khomishchak/goalsservice/GoalsServiceApplication.java
+++ b/src/main/java/com/khomishchak/goalsservice/GoalsServiceApplication.java
@@ -1,0 +1,13 @@
+package com.khomishchak.goalsservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class GoalsServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(GoalsServiceApplication.class, args);
+	}
+
+}

--- a/src/main/java/com/khomishchak/goalsservice/config/GoalServiceConfig.java
+++ b/src/main/java/com/khomishchak/goalsservice/config/GoalServiceConfig.java
@@ -1,0 +1,14 @@
+package com.khomishchak.goalsservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class GoalServiceConfig {
+
+    @Bean
+    public RestTemplate getRestTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/controller/GoalsController.java
+++ b/src/main/java/com/khomishchak/goalsservice/controller/GoalsController.java
@@ -1,0 +1,75 @@
+package com.khomishchak.goalsservice.controller;
+
+import com.khomishchak.goalsservice.model.CryptoGoalTableTransaction;
+import com.khomishchak.goalsservice.model.CryptoGoalsTable;
+import com.khomishchak.goalsservice.model.SelfGoal;
+import com.khomishchak.goalsservice.model.transaction.CreateNewRecordTransaction;
+import com.khomishchak.goalsservice.service.GoalsService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/api/v1/goals")
+public class GoalsController {
+
+    // TODO: replace @RequestHeader("UserId") with AOP poincut to extract userId before needed controllers
+
+    public static final String USER_ID_HEADER = "UserId";
+
+    private final GoalsService goalsService;
+
+    public GoalsController(GoalsService goalsService) {
+        this.goalsService = goalsService;
+    }
+
+    @PostMapping("/crypto-tables")
+    public ResponseEntity<CryptoGoalsTable> createCryptoGoalsTable(@RequestHeader(USER_ID_HEADER) Long userId,
+                                                                   @RequestBody CryptoGoalsTable requestTable) {
+        return new ResponseEntity<>(goalsService.createCryptoGoalsTable(userId, requestTable), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/crypto-tables")
+    public ResponseEntity<CryptoGoalsTable> getCryptoGoalsTable(@RequestHeader(USER_ID_HEADER) Long userId) {
+        return ResponseEntity.ok(goalsService.getCryptoGoalsTable(userId));
+    }
+
+    @PutMapping("/crypto-tables")
+    public ResponseEntity<CryptoGoalsTable> updateWholeCryptoGoalsTable(@RequestHeader(USER_ID_HEADER) Long userId,
+                                                                        @RequestBody CryptoGoalsTable cryptoGoalsTable) {
+        return ResponseEntity.ok(goalsService.updateCryptoGoalsTable(cryptoGoalsTable, userId));
+    }
+
+    @PutMapping("/{tableId}/crypto-tables")
+    public ResponseEntity<CryptoGoalsTable> updateCryptoGoalsTableWithSingleTransaction(
+            @RequestBody CryptoGoalTableTransaction transaction, @PathVariable Long tableId) {
+        return ResponseEntity.ok(goalsService.updateCryptoGoalsTable(transaction, tableId));
+    }
+
+    @PostMapping("/{tableId}/crypto-tables/new")
+    public ResponseEntity<CryptoGoalsTable> addNewRecordInCryptoGoalsTableForSingleTransaction(
+            @RequestBody CreateNewRecordTransaction transaction, @PathVariable Long tableId) {
+        return new ResponseEntity<>(goalsService.updateCryptoGoalsTable(transaction, tableId), HttpStatus.OK);
+    }
+
+    @GetMapping("/self-goals")
+    public ResponseEntity<List<SelfGoal>> getSelfGoals(@RequestHeader(USER_ID_HEADER) Long userId) {
+        return new ResponseEntity<>(goalsService.getSelfGoals(userId), HttpStatus.OK);
+    }
+
+    @PostMapping("/self-goals")
+    public ResponseEntity<List<SelfGoal>> createSelfGoals(@RequestHeader(USER_ID_HEADER) Long userId, @RequestBody List<SelfGoal> goals) {
+        return new ResponseEntity<>(goalsService.createSelfGoals(userId, goals), HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/exception/GoalsTableNotFoundException.java
+++ b/src/main/java/com/khomishchak/goalsservice/exception/GoalsTableNotFoundException.java
@@ -1,0 +1,8 @@
+package com.khomishchak.goalsservice.exception;
+
+public class GoalsTableNotFoundException extends RuntimeException {
+
+    public GoalsTableNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/CommonGoalType.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/CommonGoalType.java
@@ -1,0 +1,5 @@
+package com.khomishchak.goalsservice.model;
+
+public enum CommonGoalType {
+    DEPOSIT_GOAL
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalTableTransaction.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalTableTransaction.java
@@ -1,0 +1,35 @@
+package com.khomishchak.goalsservice.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+@Table(name = "crypto_goal_table_transactions")
+public class CryptoGoalTableTransaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ticker;
+
+    private TransactionType transactionType;
+
+    private BigDecimal quantity;
+    private BigDecimal price;
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalsTable.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalsTable.java
@@ -1,0 +1,40 @@
+package com.khomishchak.goalsservice.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+public class CryptoGoalsTable {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ElementCollection
+    @CollectionTable(name = "crypto_goals_table_records")
+    private List<CryptoGoalsTableRecord> tableRecords;
+
+    private Long userId;
+
+    public void addNewRecord(CryptoGoalsTableRecord record) {
+        tableRecords.add(record);
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalsTableRecord.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/CryptoGoalsTableRecord.java
@@ -1,0 +1,41 @@
+package com.khomishchak.goalsservice.model;
+
+import com.khomishchak.goalsservice.model.transaction.CreateNewRecordTransaction;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Transient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+@Embeddable
+public class CryptoGoalsTableRecord {
+    private String name;
+    private BigDecimal quantity;
+    private BigDecimal averageCost;
+    private BigDecimal goalQuantity;
+
+    @Transient
+    private BigDecimal donePercentage;
+
+    @Transient
+    private BigDecimal leftToBuy;
+
+    @Transient
+    private boolean finished;
+
+    public CryptoGoalsTableRecord(CreateNewRecordTransaction transaction) {
+        this.name = transaction.name();
+        this.quantity = transaction.quantity();
+        this.averageCost = transaction.price();
+        this.goalQuantity = transaction.goalQuantity();
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/CustomHeader.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/CustomHeader.java
@@ -1,0 +1,11 @@
+package com.khomishchak.goalsservice.model;
+
+public enum CustomHeader {
+    USER_ID("UserId");
+
+    private String value;
+
+    CustomHeader(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/ExchangerCode.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/ExchangerCode.java
@@ -1,0 +1,9 @@
+package com.khomishchak.goalsservice.model;
+
+public enum ExchangerCode {
+    // To be implemented:
+    BINANCE,
+    OKX,
+    // Implemented:
+    WHITE_BIT
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/GoalType.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/GoalType.java
@@ -1,0 +1,64 @@
+package com.khomishchak.goalsservice.model;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+
+public enum GoalType {
+    DAILY_DEPOSIT_GOAL {
+        @Override
+        public LocalDateTime getEndTime() {
+            return LocalDateTime.of(LocalDate.now().plusDays(1), LocalTime.MIDNIGHT);
+        }
+
+        @Override
+        public LocalDateTime getStartTime(int amountOfDaysAgo) {
+            return getEndTime().minusDays(amountOfDaysAgo);
+        }
+
+        @Override
+        public CommonGoalType getCommonType() {
+            return CommonGoalType.DEPOSIT_GOAL;
+        }
+    },
+    WEEKLY_DEPOSIT_GOAL {
+        @Override
+        public LocalDateTime getEndTime() {
+            return LocalDateTime.of(LocalDate.now().with(TemporalAdjusters.nextOrSame(java.time.DayOfWeek.MONDAY)), LocalTime.MIDNIGHT);
+        }
+
+        @Override
+        public LocalDateTime getStartTime(int amountOfWeeksAgo) {
+            return getEndTime().minusDays(7L * amountOfWeeksAgo);
+        }
+
+        @Override
+        public CommonGoalType getCommonType() {
+            return CommonGoalType.DEPOSIT_GOAL;
+        }
+    },
+    MONTHLY_DEPOSIT_GOAL {
+        @Override
+        public LocalDateTime getEndTime() {
+            return LocalDateTime.of(LocalDate.now().plusMonths(1).withDayOfMonth(1), LocalTime.MIDNIGHT);
+        }
+
+        @Override
+        public LocalDateTime getStartTime(int amountOfMonthsAgo) {
+            return getEndTime().minusMonths(amountOfMonthsAgo);
+        }
+
+        @Override
+        public CommonGoalType getCommonType() {
+            return CommonGoalType.DEPOSIT_GOAL;
+        }
+    };
+
+    public abstract LocalDateTime getEndTime();
+
+    // 1 - start time of current goal; 2 - start time of previous goal
+    public abstract LocalDateTime getStartTime(int amountOfPeriodsAgo);
+
+    public abstract CommonGoalType getCommonType();
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/SelfGoal.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/SelfGoal.java
@@ -1,0 +1,54 @@
+package com.khomishchak.goalsservice.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "self_goals")
+@ToString(exclude = "userId")
+@EqualsAndHashCode(exclude = "userId")
+public class SelfGoal {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ticker;
+
+    @Enumerated(EnumType.STRING)
+    private GoalType goalType;
+
+    private double goalAmount;
+
+    @Transient
+    private double currentAmount;
+
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    private boolean isAchieved = false;
+    // closed means that we won't have any running logic on this entity, we will be only getting the info about closed goals
+    private boolean isClosed = false;
+
+    private Long userId;
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/TransactionChangeStateDTO.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/TransactionChangeStateDTO.java
@@ -1,0 +1,11 @@
+package com.khomishchak.goalsservice.model;
+
+import lombok.Builder;
+
+import java.math.BigDecimal;
+
+@Builder
+public record TransactionChangeStateDTO(BigDecimal oldRecordQuantity, BigDecimal oldRecordAveragePrice,
+                                        BigDecimal newOperationQuantity, BigDecimal newOperationAveragePrice,
+                                        TransactionType transactionType) {
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/TransactionType.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/TransactionType.java
@@ -1,0 +1,6 @@
+package com.khomishchak.goalsservice.model;
+
+public enum TransactionType {
+    BUY,
+    SELL
+}

--- a/src/main/java/com/khomishchak/goalsservice/model/transaction/CreateNewRecordTransaction.java
+++ b/src/main/java/com/khomishchak/goalsservice/model/transaction/CreateNewRecordTransaction.java
@@ -1,0 +1,15 @@
+package com.khomishchak.goalsservice.model.transaction;
+
+import java.math.BigDecimal;
+
+public record CreateNewRecordTransaction(String name, BigDecimal quantity, BigDecimal price, BigDecimal goalQuantity) {
+
+    public CreateNewRecordTransaction {
+        if (quantity != null && BigDecimal.ZERO.compareTo(quantity) > 0) {
+            throw new IllegalArgumentException("Quantity cannot be less than zero.");
+        }
+        if (goalQuantity != null && BigDecimal.ZERO.compareTo(goalQuantity) < 0) {
+            throw new IllegalArgumentException("Goal Quantity cannot be less than zero.");
+        }
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/repository/CryptoGoalsTableRepository.java
+++ b/src/main/java/com/khomishchak/goalsservice/repository/CryptoGoalsTableRepository.java
@@ -1,0 +1,10 @@
+package com.khomishchak.goalsservice.repository;
+
+import com.khomishchak.goalsservice.model.CryptoGoalsTable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CryptoGoalsTableRepository extends JpaRepository<CryptoGoalsTable, Long> {
+    Optional<CryptoGoalsTable> findByUserId(long userId);
+}

--- a/src/main/java/com/khomishchak/goalsservice/repository/SelfGoalRepository.java
+++ b/src/main/java/com/khomishchak/goalsservice/repository/SelfGoalRepository.java
@@ -1,0 +1,24 @@
+package com.khomishchak.goalsservice.repository;
+
+import com.khomishchak.goalsservice.model.SelfGoal;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface SelfGoalRepository extends JpaRepository<SelfGoal, Long> {
+
+    List<SelfGoal> findAllByUserId(Long userId);
+
+
+
+    // TODO: add timezones handle logic
+    List<SelfGoal> findByClosedIsFalseAndEndDateBefore(LocalDateTime endDate);
+
+    default List<SelfGoal> getAllOverdueGoals() {
+        return findByClosedIsFalseAndEndDateBefore(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/service/GoalsService.java
+++ b/src/main/java/com/khomishchak/goalsservice/service/GoalsService.java
@@ -1,0 +1,31 @@
+package com.khomishchak.goalsservice.service;
+
+import com.khomishchak.goalsservice.model.CryptoGoalTableTransaction;
+import com.khomishchak.goalsservice.model.CryptoGoalsTable;
+import com.khomishchak.goalsservice.model.SelfGoal;
+import com.khomishchak.goalsservice.model.transaction.CreateNewRecordTransaction;
+
+import java.util.List;
+
+public interface GoalsService {
+
+    CryptoGoalsTable createCryptoGoalsTable(Long userId, CryptoGoalsTable tableRequest);
+
+    CryptoGoalsTable getCryptoGoalsTable(Long userId);
+
+    CryptoGoalsTable updateCryptoGoalsTable(CryptoGoalsTable cryptoGoalsTable, long userId);
+
+    CryptoGoalsTable updateCryptoGoalsTable(CryptoGoalTableTransaction transaction, long tableId);
+
+    CryptoGoalsTable updateCryptoGoalsTable(CreateNewRecordTransaction transaction, long tableId);
+
+    List<SelfGoal> getSelfGoals(Long userId);
+
+    List<SelfGoal> createSelfGoals(Long userId, List<SelfGoal> goals);
+
+    List <SelfGoal> saveAll(Iterable<SelfGoal> entities);
+
+    List<SelfGoal> getAllOverdueGoals();
+
+    boolean overdueGoalIsAchieved(SelfGoal goal);
+}

--- a/src/main/java/com/khomishchak/goalsservice/service/GoalsServiceImpl.java
+++ b/src/main/java/com/khomishchak/goalsservice/service/GoalsServiceImpl.java
@@ -1,0 +1,243 @@
+package com.khomishchak.goalsservice.service;
+
+
+import com.khomishchak.goalsservice.exception.GoalsTableNotFoundException;
+import com.khomishchak.goalsservice.model.CommonGoalType;
+import com.khomishchak.goalsservice.model.CryptoGoalTableTransaction;
+import com.khomishchak.goalsservice.model.CryptoGoalsTable;
+import com.khomishchak.goalsservice.model.CryptoGoalsTableRecord;
+import com.khomishchak.goalsservice.model.GoalType;
+import com.khomishchak.goalsservice.model.SelfGoal;
+import com.khomishchak.goalsservice.model.TransactionChangeStateDTO;
+import com.khomishchak.goalsservice.model.TransactionType;
+import com.khomishchak.goalsservice.model.transaction.CreateNewRecordTransaction;
+import com.khomishchak.goalsservice.repository.CryptoGoalsTableRepository;
+import com.khomishchak.goalsservice.repository.SelfGoalRepository;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+public class GoalsServiceImpl implements GoalsService {
+
+    public static final int PERCENTAGE_SCALE = 100;
+
+    private static final String USER_ID = "userId";
+    private static final String TICKER = "ticker";
+    private static final String GOAL_START_DATE = "fromDate";
+    private static final String GOAL_END_DATE = "toDate";
+
+
+    private String depositWithdrawalTransactionsHistoryUrl;
+
+    @Value("${ws.exchangers.authenticate.deposit-withdrawal-history.url:http://localhost:8080/balances/history/transactions/amount}")
+    public void setDepositWithdrawalHistoryUrl(String depositWithdrawalTransactionsHistoryUrl) {
+        this.depositWithdrawalTransactionsHistoryUrl = depositWithdrawalTransactionsHistoryUrl;
+    }
+
+    private final CryptoGoalsTableRepository cryptoGoalsTableRepository;
+    private final SelfGoalRepository selfGoalRepository;
+    private final Map<CommonGoalType, SelfGoalValidator> selfGoalValidators;
+    private final RestTemplate restTemplate;
+
+    public GoalsServiceImpl(CryptoGoalsTableRepository cryptoGoalsTableRepository,
+                            SelfGoalRepository selfGoalRepository, List<SelfGoalValidator> selfGoalValidators,
+                            RestTemplate restTemplate) {
+        this.cryptoGoalsTableRepository = cryptoGoalsTableRepository;
+        this.selfGoalRepository = selfGoalRepository;
+        this.selfGoalValidators = selfGoalValidators.stream()
+                .collect(Collectors.toMap(SelfGoalValidator::getCommonGoalType, validator -> validator));
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public CryptoGoalsTable createCryptoGoalsTable(Long userId, CryptoGoalsTable tableRequest) {
+        tableRequest.setUserId(userId);
+        return saveCryptoTable(tableRequest);
+    }
+
+    @Override
+    public CryptoGoalsTable getCryptoGoalsTable(Long userId) {
+        CryptoGoalsTable table  = cryptoGoalsTableRepository.findByUserId(userId).orElseThrow(
+                () -> new GoalsTableNotFoundException(String.format("could not find goals table for userId: %d", userId)));
+        table.getTableRecords().forEach(this::setPostQuantityValues);
+        return table;
+    }
+
+    @Override
+    public CryptoGoalsTable updateCryptoGoalsTable(CryptoGoalsTable cryptoGoalsTable, long userId) {
+        cryptoGoalsTable.setUserId(userId);
+        return saveCryptoTable(cryptoGoalsTable);
+    }
+
+    @Override
+    public CryptoGoalsTable updateCryptoGoalsTable(CryptoGoalTableTransaction transaction, long tableId) {
+        CryptoGoalsTable cryptoGoalsTable = getCryptoGoalsTableOrThrowException(tableId);
+        updateCryptoGoalsTableWithSingleTransaction(cryptoGoalsTable, transaction);
+        return saveCryptoTable(cryptoGoalsTable);
+    }
+
+    @Override
+    public CryptoGoalsTable updateCryptoGoalsTable(CreateNewRecordTransaction transaction, long tableId) {
+        CryptoGoalsTable table = getCryptoGoalsTableOrThrowException(tableId);
+        table.addNewRecord(new CryptoGoalsTableRecord(transaction));
+        return cryptoGoalsTableRepository.save(table);
+    }
+
+    @Override
+    public List<SelfGoal> saveAll(Iterable<SelfGoal> entities) {
+        return selfGoalRepository.saveAll(entities);
+    }
+
+    @Override
+    public List<SelfGoal> getAllOverdueGoals() {
+        return selfGoalRepository.getAllOverdueGoals();
+    }
+
+    private void updateCryptoGoalsTableWithSingleTransaction(CryptoGoalsTable cryptoGoalsTable,
+                                                             CryptoGoalTableTransaction transaction) {
+        cryptoGoalsTable.getTableRecords().forEach(record -> applyTransactionToRecord(record, transaction));
+    }
+
+    private void applyTransactionToRecord(CryptoGoalsTableRecord record, CryptoGoalTableTransaction transaction) {
+        if(!record.getName().equals(transaction.getTicker())) return;
+        record.setAverageCost(calculateNewAveragePriceAfterTransaction(record, transaction));
+        record.setQuantity(calculateNewQuantity(record, transaction));
+    }
+
+    private BigDecimal calculateNewQuantity(CryptoGoalsTableRecord oldRecord, CryptoGoalTableTransaction transaction) {
+        return TransactionType.BUY.equals(transaction.getTransactionType())
+                ? oldRecord.getQuantity().add(transaction.getQuantity())
+                : oldRecord.getQuantity().subtract(transaction.getQuantity());
+    }
+
+    private BigDecimal calculateNewAveragePriceAfterTransaction(CryptoGoalsTableRecord oldRecord,
+                                                                CryptoGoalTableTransaction transaction) {
+        TransactionChangeStateDTO transactionChangeStateDTO = mapToTransactionChangeStateDTO(oldRecord, transaction);
+        return calculateAveragePrice(transactionChangeStateDTO);
+    }
+
+    private BigDecimal calculateAveragePrice(TransactionChangeStateDTO transactionDTO) {
+        BigDecimal oldTotalValue = calculateTotalValue(transactionDTO.oldRecordAveragePrice(), transactionDTO.oldRecordQuantity());
+        BigDecimal newOperationTotalValue = calculateTotalValue(transactionDTO.newOperationAveragePrice(), transactionDTO.newOperationQuantity());
+
+        BigDecimal resultTotalPrice = null;
+        BigDecimal resultQuantity = null;
+
+        if(TransactionType.BUY.equals(transactionDTO.transactionType())) {
+            resultTotalPrice = oldTotalValue.add(newOperationTotalValue);
+            resultQuantity = transactionDTO.oldRecordQuantity().add(transactionDTO.newOperationQuantity());
+        } else {
+            resultTotalPrice = oldTotalValue.subtract(newOperationTotalValue);
+            resultQuantity = transactionDTO.oldRecordQuantity().subtract(transactionDTO.newOperationQuantity());
+        }
+
+        if (resultQuantity.compareTo(BigDecimal.ZERO) == 0) {
+            return null;
+        }
+
+        return resultTotalPrice.divide(resultQuantity, 4, RoundingMode.DOWN);
+    }
+
+    private BigDecimal calculateTotalValue(BigDecimal quantity, BigDecimal averagePrice) {
+        return quantity.multiply(averagePrice);
+    }
+
+    private TransactionChangeStateDTO mapToTransactionChangeStateDTO(CryptoGoalsTableRecord record,
+                                                                     CryptoGoalTableTransaction transaction) {
+        return TransactionChangeStateDTO.builder()
+                .newOperationAveragePrice(transaction.getPrice())
+                .newOperationQuantity(transaction.getQuantity())
+                .oldRecordAveragePrice(record.getAverageCost())
+                .oldRecordQuantity(record.getQuantity())
+                .transactionType(transaction.getTransactionType())
+                .build();
+    }
+
+    @Override
+    public List<SelfGoal> getSelfGoals(Long userId) {
+        List<SelfGoal> result = selfGoalRepository.findAllByUserId(userId);
+
+        result.forEach(goal -> {
+            goal.setCurrentAmount(requestForDepositValueForPeriod(userId, goal.getTicker(), goal.getStartDate(), goal.getEndDate()));
+            goal.setAchieved(goal.getCurrentAmount() > goal.getGoalAmount());
+        });
+        return result;
+    }
+
+    @Override
+    @Transactional
+    public List<SelfGoal> createSelfGoals(Long userId, List<SelfGoal> goals) {
+        goals.forEach(g -> {
+            GoalType goalType = g.getGoalType();
+            g.setUserId(userId);
+            g.setStartDate(goalType.getStartTime(1));
+            g.setEndDate(goalType.getEndTime());
+        });
+        return selfGoalRepository.saveAll(goals);
+    }
+
+    public boolean overdueGoalIsAchieved(SelfGoal goal) {
+        return selfGoalValidators.get(goal.getGoalType().getCommonType()).isAchieved(goal);
+    }
+
+    //TODO: will be refactored once we will start using kafka for deposit updates
+    // webhooks will be sending us the updates regarding the deposit amount, we will listen to it and set new current value to goal
+    private double requestForDepositValueForPeriod(long userId, String ticker, LocalDateTime startingDate,
+                                            LocalDateTime endingDate) {
+        // temporary change to be able to send request to balance service without passing token
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set(USER_ID, String.valueOf(userId));
+
+        URI targetUrl = UriComponentsBuilder.fromUriString(depositWithdrawalTransactionsHistoryUrl)
+                .queryParam(TICKER, ticker)
+                .queryParam(GOAL_START_DATE, startingDate.toString())
+                .queryParam(GOAL_END_DATE, endingDate.toString())
+                .queryParam("transferTransactionType", "DEPOSIT")
+                .queryParam("transactionStatus", "COMPLETED")
+                .build().encode().toUri();
+        return restTemplate.exchange(targetUrl, HttpMethod.GET, new HttpEntity<String>(headers), Double.class).getBody();
+    }
+
+    private void setPostQuantityValues(CryptoGoalsTableRecord entity) {
+        BigDecimal goalQuantity = entity.getGoalQuantity();
+        BigDecimal quantity = entity.getQuantity();
+
+        BigDecimal leftToBuy = goalQuantity.subtract(quantity);
+
+        entity.setLeftToBuy(leftToBuy.compareTo(BigDecimal.ZERO) >= 0 ? goalQuantity.subtract(quantity) : BigDecimal.ZERO);
+        entity.setDonePercentage(quantity
+                .multiply(BigDecimal.valueOf(PERCENTAGE_SCALE))
+                .divide(goalQuantity, 1, RoundingMode.DOWN));
+        entity.setFinished(quantity.compareTo(goalQuantity) >= 0);
+    }
+
+    CryptoGoalsTable saveCryptoTable(CryptoGoalsTable table) {
+        CryptoGoalsTable createdTable = cryptoGoalsTableRepository.save(table);
+        createdTable.getTableRecords().forEach(this::setPostQuantityValues);
+        return createdTable;
+    }
+
+    private CryptoGoalsTable getCryptoGoalsTableOrThrowException(long tableId) {
+        return cryptoGoalsTableRepository.findById(tableId)
+                .orElseThrow(() -> new GoalsTableNotFoundException(String.format("CryptoGoalsTable with id: %s was not found", tableId)));
+    }
+}

--- a/src/main/java/com/khomishchak/goalsservice/service/SelfGoalValidator.java
+++ b/src/main/java/com/khomishchak/goalsservice/service/SelfGoalValidator.java
@@ -1,0 +1,12 @@
+package com.khomishchak.goalsservice.service;
+
+
+import com.khomishchak.goalsservice.model.CommonGoalType;
+import com.khomishchak.goalsservice.model.SelfGoal;
+
+public interface SelfGoalValidator {
+
+    CommonGoalType getCommonGoalType();
+
+    boolean isAchieved(SelfGoal goal);
+}

--- a/src/main/java/com/khomishchak/goalsservice/service/impl/DepositSelfGoalValidator.java
+++ b/src/main/java/com/khomishchak/goalsservice/service/impl/DepositSelfGoalValidator.java
@@ -1,0 +1,47 @@
+package com.khomishchak.goalsservice.service.impl;
+
+import com.khomishchak.goalsservice.model.CommonGoalType;
+import com.khomishchak.goalsservice.model.SelfGoal;
+import com.khomishchak.goalsservice.service.SelfGoalValidator;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+
+@Component
+public class DepositSelfGoalValidator implements SelfGoalValidator {
+
+    private String getDepositAmountUrl;
+
+    private final static CommonGoalType GOAL_TYPE = CommonGoalType.DEPOSIT_GOAL;
+
+    @Value("${ws.exchanger.deposit.amount.url:http://localhost:8080/balances/transactions-history/period}")
+    public void setGetDepositAmountUrl(String getDepositAmountUrl) {
+        this.getDepositAmountUrl = getDepositAmountUrl;
+    }
+
+    private final RestTemplate restTemplate;
+
+    public DepositSelfGoalValidator(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public CommonGoalType getCommonGoalType() {
+        return GOAL_TYPE;
+    }
+
+    @Override
+    public boolean isAchieved(SelfGoal goal) {
+        double depositValue = getDepositValueForPeriod(goal.getUserId(), goal.getTicker());
+        goal.setCurrentAmount(depositValue);
+        return depositValue > goal.getGoalAmount();
+    }
+
+    private Double getDepositValueForPeriod(long userId, String ticker) {
+        return restTemplate.getForObject(getDepositAmountUrl, Double.class, userId, ticker);
+    }
+
+
+}

--- a/src/main/java/com/khomishchak/goalsservice/service/scheduled/GoalsScheduledService.java
+++ b/src/main/java/com/khomishchak/goalsservice/service/scheduled/GoalsScheduledService.java
@@ -1,0 +1,55 @@
+package com.khomishchak.goalsservice.service.scheduled;
+
+import com.khomishchak.goalsservice.model.GoalType;
+import com.khomishchak.goalsservice.model.SelfGoal;
+import com.khomishchak.goalsservice.repository.SelfGoalRepository;
+
+import com.khomishchak.goalsservice.service.GoalsService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class GoalsScheduledService {
+
+    private final GoalsService goalsService;
+
+    public GoalsScheduledService(GoalsService goalsService) {
+        this.goalsService = goalsService;
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void doAtTheStartOfTheDay() {
+        List<SelfGoal> overdueGoals = goalsService.getAllOverdueGoals();
+        closeOverdueAndCreateNewGoals(overdueGoals);
+    }
+
+    private void closeOverdueAndCreateNewGoals(List<SelfGoal> overdueGoals) {
+        List<SelfGoal> updatedGoals = new ArrayList<>();
+        overdueGoals.forEach(overdueGoal -> {
+            closeOverdueGoal(overdueGoal);
+            SelfGoal newGoal = createNewFromOverdueGoal(overdueGoal);
+            updatedGoals.addAll(List.of(overdueGoal, newGoal));
+        });
+        goalsService.saveAll(updatedGoals);
+    }
+
+    private void closeOverdueGoal(SelfGoal overdueGoal) {
+        overdueGoal.setAchieved(goalsService.overdueGoalIsAchieved(overdueGoal));
+        overdueGoal.setClosed(true);
+    }
+
+    private SelfGoal createNewFromOverdueGoal(SelfGoal overdueGoal) {
+        GoalType goalType = overdueGoal.getGoalType();
+        return SelfGoal.builder()
+                .ticker(overdueGoal.getTicker())
+                .userId(overdueGoal.getUserId())
+                .goalAmount(overdueGoal.getGoalAmount())
+                .goalType(goalType)
+                .startDate(goalType.getStartTime(1))
+                .endDate(goalType.getEndTime())
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: "jdbc:postgresql://localhost:5432/crypto"
+    username: "postgres"
+    password: "1111"
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: "org.hibernate.dialect.PostgreSQLDialect"
+        format_sql: false
+        globally_quoted_identifiers: true
+server:
+  port: 43654

--- a/src/test/java/com/khomishchak/goalsservice/GoalsServiceApplicationTests.java
+++ b/src/test/java/com/khomishchak/goalsservice/GoalsServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.khomishchak.goalsservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GoalsServiceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}


### PR DESCRIPTION
* move goals service to separate service init commit

* set userId on crypto table update request

* add transactions with creating new records for table

before now users could create update transactions only for the records that already existed in the table with given new endpoint we will be able to create new records by single transactions, without updating whole goals table

* updated call to balance service for transactions history deposit amount

the fix was to add userId custom header as we do not have any token to go through auth service, and no creds to create token and in as war as this will be a public API without token validation and so userId exctraction we are passing it mannually note it is a quick fix, it will be replaced with event driving architecture soon

* applied suggestions

* small refactor

---------